### PR TITLE
Safari 9

### DIFF
--- a/Ka-Block.safariextension/Info.plist
+++ b/Ka-Block.safariextension/Info.plist
@@ -23,6 +23,8 @@
 	</dict>
 	<key>Content</key>
 	<dict>
+		<key>Content Blocker</key>
+		<string>blockerList.json</string>
 		<key>Scripts</key>
 		<dict>
 			<key>Start</key>

--- a/Ka-Block.safariextension/filter.js
+++ b/Ka-Block.safariextension/filter.js
@@ -34,4 +34,7 @@ function init() {
   req.send()
 }
 
-init()
+// Content Blocker polyfill for Safari 8 and under
+if (!('onwebkitmouseforcedown' in window)) {
+  init()
+}

--- a/Ka-Block.safariextension/start.js
+++ b/Ka-Block.safariextension/start.js
@@ -1,32 +1,36 @@
-// Remember domain filter results.
-const cache = new Map()
+// Content Blocker polyfill for Safari 8 and under
+if (!('onwebkitmouseforcedown' in window)) {
+  // Remember domain filter results.
+  const cache = new Map()
 
-// Check with global page for approval.
-function blocked(event, url) {
-  var result = cache.get(url.hostname)
-  if (result === undefined) {
-    result = safari.self.tab.canLoad(event, url.href) === 'block'
-    cache.set(url.hostname, result)
+  // Check with global page for approval.
+  function blocked(event, url) {
+    var result = cache.get(url.hostname)
+    if (result === undefined) {
+      result = safari.self.tab.canLoad(event, url.href) === 'block'
+      cache.set(url.hostname, result)
+    }
+    return result
   }
-  return result
+
+  // Filter all external resource requests.
+  document.addEventListener('beforeload', function(event) {
+    // Resolve relative URLs.
+    const url = new URL(event.url, window.location.href)
+
+    // Skip about:blank, data:image, etc.
+    if (!url.origin || url.origin === 'null') {
+      return
+    }
+
+    // Allow same origin resources.
+    if (window.location.origin === url.origin) {
+      return
+    }
+
+    if (blocked(event, url)) {
+      console.info('Content blocker prevented frame displaying ' + window.location.href + ' from loading a resource from ' + event.url)
+      event.preventDefault()
+    }
+  }, true)
 }
-
-// Filter all external resource requests.
-document.addEventListener('beforeload', function(event) {
-  // Resolve relative URLs.
-  const url = new URL(event.url, window.location.href)
-
-  // Skip about:blank, data:image, etc.
-  if (!url.origin || url.origin === 'null') {
-    return
-  }
-
-  // Allow same origin resources.
-  if (window.location.origin === url.origin) {
-    return
-  }
-
-  if (blocked(event, url)) {
-    event.preventDefault()
-  }
-}, true)


### PR DESCRIPTION
This registers the `blockerList.json` list as a native Content Blocker in Safari 9. Support for Safari 8 is preserved and the polyfill JS is skipped on Safari 9.

I couldn't find a great feature check for this feature on Safari 9 vs 8. So I ended up testing the new force touch event which was added in Safari 9. Seemed better than trying to write a User Agent string regexp test.

If and when we chose to only support Safari 9, the `start.js`, `index.html` and `filter.js` can all be removed. It'll be great to avoid loading the additional scripts on every page load. 