### PR TITLE
Remove DevelopmentTeam

### DIFF
--- a/Ka-Block.xcodeproj/project.pbxproj
+++ b/Ka-Block.xcodeproj/project.pbxproj
@@ -164,11 +164,9 @@
 				TargetAttributes = {
 					03FCD00B1B2AA68A00076943 = {
 						CreatedOnToolsVersion = 7.0;
-						DevelopmentTeam = UYW4V22L7E;
 					};
 					03FCD0241B2AA77600076943 = {
 						CreatedOnToolsVersion = 7.0;
-						DevelopmentTeam = UYW4V22L7E;
 					};
 				};
 			};


### PR DESCRIPTION
I wish there was an easier way to *gitignore* this property. I don't think we want to check it cause its just @dgraham's id.