### PR TITLE
Remove broken extension detection

### DIFF
--- a/Ka-Block/AppDelegate.swift
+++ b/Ka-Block/AppDelegate.swift
@@ -1,5 +1,4 @@
 import UIKit
-import SafariServices
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -7,22 +6,5 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         return true
-    }
-
-    var extensionEnabled = false {
-        didSet {
-            if let viewController = self.window?.rootViewController as? ViewController {
-                viewController.extensionEnabled = extensionEnabled
-            }
-        }
-    }
-
-    func applicationDidBecomeActive(application: UIApplication) {
-        extensionEnabled = false
-        SFContentBlockerManager.reloadContentBlockerWithIdentifier("com.kablock.Ka-Block.Ka-Block-Content-Blocker") { error in
-            dispatch_async(dispatch_get_main_queue()) {
-                self.extensionEnabled = true
-            }
-        }
     }
 }

--- a/Ka-Block/Base.lproj/Main.storyboard
+++ b/Ka-Block/Base.lproj/Main.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="8121.17" systemVersion="14E46" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="8187.4" systemVersion="15A262e" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8101.14"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8151.3"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
     </dependencies>
@@ -18,23 +18,30 @@
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ev1-ds-S9A" userLabel="Banner">
-                                <rect key="frame" x="0.0" y="0.0" width="600" height="379"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ev1-ds-S9A" userLabel="Banner">
+                                <rect key="frame" x="0.0" y="0.0" width="600" height="396"/>
+                                <animations/>
                                 <color key="backgroundColor" red="1" green="0.2196078431372549" blue="0.14117647058823529" alpha="1" colorSpace="calibratedRGB"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" image="Home" translatesAutoresizingMaskIntoConstraints="NO" id="rn8-cC-WZd">
-                                <rect key="frame" x="0.0" y="9" width="600" height="370"/>
+                            <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Home" translatesAutoresizingMaskIntoConstraints="NO" id="rn8-cC-WZd">
+                                <rect key="frame" x="0.0" y="40" width="600" height="316"/>
+                                <animations/>
                             </imageView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Disabled" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0gh-j2-yu1">
-                                <rect key="frame" x="267" y="488" width="67" height="21"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0gh-j2-yu1">
+                                <rect key="frame" x="185" y="467" width="231.5" height="61"/>
+                                <animations/>
+                                <string key="text">Enable the Safari extension
+to prevent ads from appearing
+on web pages.</string>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
+                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="rn8-cC-WZd" firstAttribute="trailing" secondItem="ev1-ds-S9A" secondAttribute="trailing" id="Oea-t8-DE5"/>

--- a/Ka-Block/ViewController.swift
+++ b/Ka-Block/ViewController.swift
@@ -3,16 +3,6 @@ import UIKit
 class ViewController: UIViewController {
     @IBOutlet weak var label: UILabel!
 
-    var extensionEnabled = false {
-        didSet {
-            if extensionEnabled {
-                self.label.text = "Ad blocking is enabled.\nYou’re all set!"
-            } else {
-                self.label.text = "Enable the Safari extension\nto prevent ads from appearing\non web pages."
-            }
-        }
-    }
-
     override func preferredStatusBarStyle() -> UIStatusBarStyle {
         return UIStatusBarStyle.LightContent;
     }


### PR DESCRIPTION
Hmm, so they fixed the bug where `reloadContentBlockerWithIdentifier` wouldn't respond if the extension wasn't enabled. It always returns.

I thought, it might give a different `error` code depending, but its always `nil` if the extension is enabled or disabled.

I don't think this is going to be possible in the initial iOS 9. Any other ideas?

-

To: @dgraham 