### PR TITLE
Fix Safari 9 Extensions Gallery link

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,4 +81,5 @@ file for details.
 <3
 
 [latest]: https://github.com/dgraham/Ka-Block/releases/latest
-[gallery]: https://extensions.apple.com/details/?id=com.negativecode.safari.ka-block-UYW4V22L7E
+[gallery]: https://safari-extensions.apple.com/details/?id=com.kablock.osx-UYW4V22L7E
+


### PR DESCRIPTION
I believe this is the correct link for ka-block in the extension gallery.  The current link doesn't work when you try and install from the Safari (see attached image).

<img width="519" alt="screenshot 2015-10-10 10 11 07" src="https://cloud.githubusercontent.com/assets/11152/10411792/4380c84a-6f37-11e5-90d5-2d34506f2d5f.png">
