### PR TITLE
Add xiti.com in filtered urls and cleanup dailymotion.com

### DIFF
--- a/Ka-Block.safariextension/filters.json
+++ b/Ka-Block.safariextension/filters.json
@@ -4239,5 +4239,17 @@
     "action": {
       "type": "block"
     }
+  },
+  {
+    "trigger": {
+      "url-filter": "^https?:/+([^/:]+\\.)?xiti\\.com[:/]",
+      "url-filter-is-case-sensitive": true,
+      "load-type": [
+        "third-party"
+      ]
+    },
+    "action": {
+      "type": "block"
+    }
   }
 ]

--- a/Ka-Block.safariextension/filters.json
+++ b/Ka-Block.safariextension/filters.json
@@ -4251,5 +4251,41 @@
     "action": {
       "type": "block"
     }
+  },
+  {
+    "trigger": {
+      "url-filter": "^https?:/+([^/:]+\\.)?dmcdn\\.net/mc/[:/]",
+      "url-filter-is-case-sensitive": true,
+      "load-type": [
+        "third-party"
+      ]
+    },
+    "action": {
+      "type": "block"
+    }
+  },
+  {
+    "trigger": {
+      "url-filter": "^https?:/+([^/:]+\\.)?ad\\.pxlad\\.io[:/]",
+      "url-filter-is-case-sensitive": true,
+      "load-type": [
+        "third-party"
+      ]
+    },
+    "action": {
+      "type": "block"
+    }
+  },
+  {
+    "trigger": {
+      "url-filter": "^https?:/+([^/:]+\\.)?measuread\\.com[:/]",
+      "url-filter-is-case-sensitive": true,
+      "load-type": [
+        "third-party"
+      ]
+    },
+    "action": {
+      "type": "block"
+    }
   }
 ]

--- a/Ka-Block.safariextension/filters.json
+++ b/Ka-Block.safariextension/filters.json
@@ -4299,5 +4299,17 @@
     "action": {
       "type": "block"
     }
+  },
+  {
+    "trigger": {
+      "url-filter": "^https?:/+([^/:]+\\.)?ads-twitter\\.com[:/]",
+      "url-filter-is-case-sensitive": true,
+      "load-type": [
+        "third-party"
+      ]
+    },
+    "action": {
+      "type": "block"
+    }
   }
 ]

--- a/Ka-Block.safariextension/filters.json
+++ b/Ka-Block.safariextension/filters.json
@@ -4287,5 +4287,17 @@
     "action": {
       "type": "block"
     }
+  },
+  {
+    "trigger": {
+      "url-filter": "^https?:/+([^/:]+\\.)?nuggad\\.net[:/]",
+      "url-filter-is-case-sensitive": true,
+      "load-type": [
+        "third-party"
+      ]
+    },
+    "action": {
+      "type": "block"
+    }
   }
 ]


### PR DESCRIPTION
9bbf3d57b23c2360ecc03625960b10035e356b0c
xiti.com is a domain used by ATInternet (http://www.atinternet.com) to make analytics.
French websites like http://www.lemonde.fr use this analytics. 

18a9e5db2b4202a0edadb91dd29a6a9881817a14
Cleanup dailymotion.com (French streaming provider) by adding 3 domains to filters :
dmcdn.net
ad.pxlad.io
measuread.com

2d78bc5b818430b417bde91be5d44e14bba6dab7
Add nuggad.net to filters (https://www.nugg.ad/). It's an analytics used for example on website http://www.lefigaro.fr

a5f45e2abfc70aa84c23b237e4213d3af2eb5646
Remove ads on twitter.com by adding ads-twitter.com in filtered urls