### PR TITLE
Set Signing Team configuration to None

### DIFF
--- a/Ka-Block.xcodeproj/project.pbxproj
+++ b/Ka-Block.xcodeproj/project.pbxproj
@@ -164,12 +164,10 @@
 				TargetAttributes = {
 					03FCD00B1B2AA68A00076943 = {
 						CreatedOnToolsVersion = 7.0;
-						DevelopmentTeam = UYW4V22L7E;
 						LastSwiftMigration = 0800;
 					};
 					03FCD0241B2AA77600076943 = {
 						CreatedOnToolsVersion = 7.0;
-						DevelopmentTeam = UYW4V22L7E;
 						LastSwiftMigration = 0800;
 					};
 				};
@@ -361,7 +359,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = UYW4V22L7E;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "Ka-Block/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -379,7 +377,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = UYW4V22L7E;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "Ka-Block/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -395,7 +393,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = UYW4V22L7E;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "Ka-Block Content Blocker/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.kablock.ios.Ka-Block-Content-Blocker";
@@ -411,7 +409,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = UYW4V22L7E;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "Ka-Block Content Blocker/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.kablock.ios.Ka-Block-Content-Blocker";


### PR DESCRIPTION
When I open the Ka-Block project on a new machine the project's build settings are in an error state because I don't have @dgraham's private team signing configuration.

<img width="704" alt="screen shot 2017-08-31 at 2 19 22 pm" src="https://user-images.githubusercontent.com/137/29945836-b0d1cbb0-8e57-11e7-9b5a-e5dc151da70c.png">

I usually just set this to `None`—which automatically detects a local developer signing team.

I don't think this ID is harmful to have leaked, but isn't useful to anyone else.

I'm hoping the `None` value automatically picks this team ID on @dgraham's local machine so this change doesn't annoy him either.