### PR TITLE
Conditionally unwrap optional state

### DIFF
--- a/Ka-Block/iOS/ViewController.swift
+++ b/Ka-Block/iOS/ViewController.swift
@@ -23,10 +23,10 @@ class ViewController: UIViewController {
         SFContentBlockerManager.getStateOfContentBlocker(withIdentifier: "com.kablock.ios.Ka-Block-Content-Blocker", completionHandler: {
             (state, error) in
 
-            if state != nil {
+            if let state = state {
                 DispatchQueue.main.async {
-                    self.enabledLabel.isHidden = !state!.isEnabled
-                    self.disabledLabel.isHidden = state!.isEnabled
+                    self.enabledLabel.isHidden = !state.isEnabled
+                    self.disabledLabel.isHidden = state.isEnabled
                 }
             }
         })


### PR DESCRIPTION
Instead of forcibly unwrapping state with `state!`, the conditional can do the work and rebind an unwrapped `state` in its branch.