### PR TITLE
Set macOS product name to "Ka-Block!"

### DIFF
--- a/Ka-Block.xcodeproj/project.pbxproj
+++ b/Ka-Block.xcodeproj/project.pbxproj
@@ -468,7 +468,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Ka-Block/macOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kablock.macos;
-				PRODUCT_NAME = "$(PRODUCT_NAME)";
+				PRODUCT_NAME = "Ka-Block!";
 				SDKROOT = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
@@ -489,7 +489,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Ka-Block/macOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kablock.macos;
-				PRODUCT_NAME = "$(PRODUCT_NAME)";
+				PRODUCT_NAME = "Ka-Block!";
 				SDKROOT = macosx;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 4.0;


### PR DESCRIPTION
Through some brute force I was able to configure this other `PRODUCT_NAME` variable to "Ka-Block!" to resolve #75. I don't think it's possible to change this through the UI—or at least I couldn't find it. Ended up editing the config directly.

<img width="535" alt="screen shot 2017-11-22 at 8 51 44 pm" src="https://user-images.githubusercontent.com/137/33159379-4401d96a-cfc7-11e7-83d7-a0d86724ac15.png">

Here is my nuke script for clobbering any test data.

``` sh
#!/bin/bash

osascript -e 'quit app "Safari"'
osascript -e 'quit app "Xcode"'

git clean -fdx Ka-Block.xcodeproj/

rm -rf "$HOME/Library/Developer/Xcode/DerivedData"
rm -rf "$HOME/Library/Developer/Xcode/Archives"
```

Fixes #75.