### PR TITLE
feat: Block adservice.google.com

### DIFF
--- a/Shared (Extension)/blockerList.json
+++ b/Shared (Extension)/blockerList.json
@@ -2283,6 +2283,16 @@
   },
   {
     "trigger": {
+      "url-filter": "^https?:/+([^/:]+\\.)?adservice\\.google\\.com[:/]",
+      "url-filter-is-case-sensitive": true,
+      "load-type": ["third-party"]
+    },
+    "action": {
+      "type": "block"
+    }
+  },
+  {
+    "trigger": {
       "url-filter": "^https?:/+([^/:]+\\.)?googlesyndication\\.com[:/]",
       "url-filter-is-case-sensitive": true,
       "load-type": ["third-party"]


### PR DESCRIPTION
Block adservice.google.com, which was encountered when visiting
https://www.espn.com.
