### PR TITLE
Make /s_code.js filter more precise

### DIFF
--- a/Shared (Extension)/blockerList.json
+++ b/Shared (Extension)/blockerList.json
@@ -31,7 +31,7 @@
   },
   {
     "trigger": {
-      "url-filter": "/s_code.js",
+      "url-filter": "/s_code\\.js",
       "url-filter-is-case-sensitive": true,
       "load-type": ["third-party", "first-party"]
     },


### PR DESCRIPTION
The dot was matching any character, so this filter caused https://a0.awsstatic.com/s_code/js/3.0/awshome_s_code.js to be blocked, breaking all AWS documentation.

Fixes #193
